### PR TITLE
Fix: Sanitize model name for log directory path to prevent OSError on Windows

### DIFF
--- a/src/llm/vgagent.py
+++ b/src/llm/vgagent.py
@@ -60,7 +60,8 @@ class VideoGameBenchAgent:
                  api_base: Optional[str] = None):
         # Set up logging directory
         if log_dir is None:
-            model_name = model.replace("/", "-").replace(".", "-").replace(":", "-") # fix
+            # Remove .,: for compatability with Windows file systems
+            model_name = model.replace("/", "-").replace(".", "-").replace(":", "-")
             self.log_dir = Path("logs") / f"{game.lower()}" / model_name / datetime.now().strftime("%Y%m%d_%H%M%S")
             self.log_dir.mkdir(parents=True, exist_ok=True)
         else:

--- a/src/llm/vgagent.py
+++ b/src/llm/vgagent.py
@@ -60,7 +60,7 @@ class VideoGameBenchAgent:
                  api_base: Optional[str] = None):
         # Set up logging directory
         if log_dir is None:
-            model_name = model.replace("/", "-").replace(".", "-")
+            model_name = model.replace("/", "-").replace(".", "-").replace(":", "-") # fix
             self.log_dir = Path("logs") / f"{game.lower()}" / model_name / datetime.now().strftime("%Y%m%d_%H%M%S")
             self.log_dir.mkdir(parents=True, exist_ok=True)
         else:


### PR DESCRIPTION
## Problem

When running VideoGameBench on Windows with a model name containing a colon (e.g., `ollama/llava:7b-v1.6` or `llava:7b-v1.6`), the application fails to create the log directory. This occurs because colons are not permitted characters in directory or file names on the Windows operating system.

The specific error encountered is:
```
OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect: 'logs\\\\game_name\\\\model:name-with-colon\\\\timestamp'
```

This issue was observed when attempting to execute commands such as:
```bash
python main.py --game doom --model ollama/llava:7b-v1.6 --api-base http://localhost:11434 --enable-ui --max-context-size 10
```
or
```bash
python main.py --game doom --model llava:7b-v1.6 --api-base http://localhost:11434 --enable-ui --max-context-size 10
```

During the setup process, it was also noted that `imagehash` and `playwright` might be missing from the environment, which can lead to `ModuleNotFoundError`. These dependencies can be installed using:
```bash
pip install imagehash
pip install playwright
pip install sv_ttk
playwright install # Required by Playwright to download browser binaries
```

## Solution

This pull request resolves the `OSError` by modifying the `VideoGameBenchAgent` (and consequently, `LLMClient`) to correctly sanitize model names when constructing log directory paths. The fix involves replacing colons (`:`) with hyphens (`-`), which aligns with the existing sanitization logic for slashes (`/`) and periods (`.`).

The modification is located in `src/llm/vgagent.py` within the `VideoGameBenchAgent.__init__` method:

```python
# Before
model_name = model.replace("/", "-").replace(".", "-")

# After
model_name = model.replace("/", "-").replace(".", "-").replace(":", "-")
```

This change ensures that directory paths are generated in a Windows-compatible format, such as `logs\\doom\\ollama-llava-7b-v1-6\\timestamp`.


This modification is expected to be cross-platform compatible, as hyphens are valid characters in directory names on all major operating systems.